### PR TITLE
[feat] Add support for modded cars, use server provided data and fallback to bundled

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -144,6 +144,7 @@ class DashboardHandler(BaseHTTPRequestHandler):
             if route.startswith("/static/"):
                 return self._serve_static(route[len("/static/") :])
             if route == "/api/metadata":
+                metadata.rebuild_metadata()
                 return self._send_json(metadata.build_metadata())
             if route == "/api/config":
                 form = config_io.effective_runtime_form(self.config.config_path, os.environ)

--- a/dashboard/metadata.py
+++ b/dashboard/metadata.py
@@ -184,3 +184,7 @@ def build_metadata() -> dict:
         "categories": _categories(),
         "defaults": _defaults(cfg),
     }
+
+def rebuild_metadata():
+    lp.load_config.cache_clear()     # clear the launch_payloads cache
+    build_metadata.cache_clear()     # clear our own cache

--- a/scripts/launch_payloads.py
+++ b/scripts/launch_payloads.py
@@ -568,6 +568,77 @@ def load_server_launcher_json(env: dict[str, str], cfg: dict) -> LauncherImport:
     map_launcher_waiting_for_players(launcher, sessions)
     return launcher
 
+def load_mapping_file(scripts_dir: Path, install_data_dir: Path, filename: str):
+    volume_path = install_data_dir / filename
+    bundled_path = scripts_dir / "mappings" / filename
+
+    # 1. Try reading server owned files
+    try:
+        if volume_path.exists():
+            return _read_json(volume_path)
+    except Exception:
+        pass
+
+    # 2. Fallback to the bundled file
+    return _read_json(bundled_path)
+
+def normalize_cars(data) -> list[dict]:
+    """Convert volume format ({"cars": [...]}) or plain list to internal car list."""
+    # Unwrap dict with "cars" key
+    if isinstance(data, dict) and "cars" in data:
+        data = data["cars"]
+
+    if not isinstance(data, list):
+        return []
+
+    cars = []
+    for car in data:
+        if not isinstance(car, dict):
+            continue
+
+        if "name" in car and "internal_name" not in car:
+            car = dict(car)
+            car["internal_name"] = car.pop("name")
+
+        cars.append(car)
+
+    return cars
+
+def load_mod_cars(install_data_dir: Path, existing_cars: list[dict]) -> list[dict]:
+    # Path: <install_dir>/steamapps/compatdata/4564210/pfx/drive_c/users/*/Saved Games/ACE-Server/mods/
+    users_base = install_data_dir / "steamapps" / "compatdata" / "4564210" / "pfx" / "drive_c" / "users"
+    if not users_base.exists():
+        return existing_cars
+
+    known_names = {
+        car["internal_name"]
+        for car in existing_cars
+        if "internal_name" in car
+    }
+
+    for user_dir in users_base.iterdir():
+        if not user_dir.is_dir():
+            continue
+
+        mods_dir = user_dir / "Saved Games" / "ACE-Server" / "mods"
+
+        if not mods_dir.is_dir():
+            continue
+
+        for mod_file in mods_dir.glob("*.json"):
+            try:
+                mod_data = _read_json(mod_file)
+                for car in normalize_cars(mod_data):
+                    internal_name = car.get("internal_name")
+                    if not internal_name or internal_name in known_names:
+                        continue
+
+                    existing_cars.append(car)
+                    known_names.add(internal_name)
+            except Exception:
+                continue
+
+    return existing_cars
 
 @lru_cache(maxsize=1)
 def load_config() -> dict:
@@ -578,10 +649,15 @@ def load_config() -> dict:
 
     defaults = _read_json(root / "defaults.json")
 
+    install_data_dir = Path(os.environ.get("ACEVO_SERVER_INSTALL_DIR", "/data/server"))
+
     try:
-        cars = _read_json(scripts_dir / "mappings" / "cars.json")
+        cars_raw = load_mapping_file(scripts_dir, install_data_dir, "cars.json")
+        cars = normalize_cars(cars_raw)
     except Exception:
         cars = []
+
+    cars = load_mod_cars(install_data_dir, cars)
 
     car_lookup = {normalize_label(item["display_name"]): item["internal_name"] for item in cars}
     cars_data = cars
@@ -589,7 +665,7 @@ def load_config() -> dict:
     tracks_by_event: dict[str, dict[str, dict]] = {"GameModeType_PRACTICE": {}, "GameModeType_RACE_WEEKEND": {}}
 
     try:
-        practice_tracks = _read_json(scripts_dir / "mappings" / "events_practice.json")
+        practice_tracks = load_mapping_file(scripts_dir, install_data_dir, "events_practice.json")
         for track in practice_tracks.get("events", []):
             for alias in track_aliases(track):
                 tracks_by_event["GameModeType_PRACTICE"][alias] = track
@@ -597,7 +673,7 @@ def load_config() -> dict:
         pass
 
     try:
-        race_tracks = _read_json(scripts_dir / "mappings" / "events_race_weekend.json")
+        race_tracks = load_mapping_file(scripts_dir, install_data_dir, "events_race_weekend.json")
         for track in race_tracks.get("events", []):
             for alias in track_aliases(track):
                 tracks_by_event["GameModeType_RACE_WEEKEND"][alias] = track


### PR DESCRIPTION
This PR provides a implementation of using the server provided `cars.json`, `events_practice.json` and `events_race_weekend.json` as well as creating initial support to allow adding modded cars.
The UI will reflect changed .json and modded cars after a page refresh.

**Temporary**
* Changed `/api/metadata` endpoint to rebuild the metadata, so new added mods or changed content is reflected in the ui after a page refresh.

**Car and track mapping improvements:**
* Added `load_mapping_file` to allow server-provided files (in `install_data_dir`) to override bundled files, improving flexibility for future updates.
* Added `normalize_cars` to standardize car data from different formats, and `load_mod_cars` to merge user mod cars from the server’s data directory into the car list, preventing duplicates.
* Updated the main config loading logic to use these new functions for cars and tracks, supporting both overrides and mods seamlessly.